### PR TITLE
fix markdown language for code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm i @rttnbrgr/gatsby-theme-soundcloud
 
 Setup the plugin in `gatsby-config.js` with the rest of your plugins.
 
-```gatsby-config.js
+```js:title=gatsby-config.js
 module.exports = {
   plugins: [
     {


### PR DESCRIPTION
to avoid warning:

```
warn unable to find prism language 'gatsby-config.js' for highlighting. applying generic code block
```